### PR TITLE
ci: build PR-tagged docker image on pull_request

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,9 @@ on:
       - "docs/**"
     tags:
       - "v*.*.*"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
 
 env:
   REGISTRY: ghcr.io
@@ -50,9 +53,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # type=ref,event=pr emits "pr-N" only on pull_request triggers,
+          # so a PR build pushes ghcr.io/.../openbooks:pr-42 (and a sha
+          # tag) without touching :latest. master pushes still own :latest.
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
+            type=ref,event=pr
             type=sha
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- Adds `pull_request` to the Docker workflow's trigger list (with the same `paths-ignore: docs/**` as the master push trigger)
- Appends `type=ref,event=pr` to the metadata-action tags so PR builds push `ghcr.io/abnormalend/openbooks:pr-N` (plus the standard `sha-…` tag)
- Master continues to own `:latest` (gated by `is_default_branch`) and tagged releases continue to drive multi-arch builds — PRs stay amd64-only for fast feedback

## Test plan

- [x] Local YAML lint (`python3 -c \"import yaml; yaml.safe_load(...)\"`)
- [ ] **This PR's own build is the live test** — once CI completes, expected new tags on GHCR:
  - `ghcr.io/abnormalend/openbooks:pr-9`
  - `ghcr.io/abnormalend/openbooks:sha-<short>`
- [ ] `:latest` is **not** updated (verify via the GHCR package versions page)

## Notes

GHCR keeps PR images even after the PR closes; if you want auto-cleanup later, the standard pattern is a small workflow that runs on `pull_request: closed` and deletes the matching `pr-N` tag via `actions/delete-package-versions`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)