### PR TITLE
chore(docker): default to port 8080 + document non-root usage (#10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ FROM gcr.io/distroless/static AS app
 WORKDIR /app
 COPY --from=build /go/src/cmd/openbooks/openbooks .
 
-EXPOSE 80
+EXPOSE 8080
 VOLUME [ "/books" ]
 ENV BASE_PATH=/
 
-ENTRYPOINT ["./openbooks", "server", "--dir", "/books", "--port", "80"]
+# Default to a non-privileged port so the container can be run as a
+# non-root user (e.g. `--user 1000:1000`) without needing
+# cap_net_bind_service. See docs/docs/setup/docker.md for details.
+ENTRYPOINT ["./openbooks", "server", "--dir", "/books", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Openbooks allows you to download ebooks from irc.irchighway.net quickly and easi
 ### Docker
 
 - Basic config
-  - `docker run -p 8080:80 evanbuss/openbooks`
+  - `docker run -p 8080:8080 evanbuss/openbooks`
 - Config to persist all eBook files to disk
-  - `docker run -p 8080:80 -v /home/evan/Downloads/openbooks:/books evanbuss/openbooks --persist`
+  - `docker run -p 8080:8080 -v /home/evan/Downloads/openbooks:/books evanbuss/openbooks --persist`
 
 ### Setting the Base Path
 
 OpenBooks server doesn't have to be hosted at the root of your webserver. The basepath value allows you to host it behind a reverse proxy. The base path value must have opening and closing forward slashes (default "/").
 
 - Docker
-  - `docker run -p 8080:80 -e BASE_PATH=/openbooks/ evanbuss/openbooks`
+  - `docker run -p 8080:8080 -e BASE_PATH=/openbooks/ evanbuss/openbooks`
 - Binary
   - `./openbooks server --basepath /openbooks/`
 

--- a/docker.md
+++ b/docker.md
@@ -6,15 +6,15 @@
 
 ### Basic
 
-`docker run -d -p 8080:80 evanbuss/openbooks --name my_irc_name`
+`docker run -d -p 8080:8080 evanbuss/openbooks --name my_irc_name`
 
 ### Persist eBook Files
 
-`docker run -d -p 8080 -v ~/Downloads:/books evanbuss/openbooks --name my_irc_name --persist`
+`docker run -d -p 8080:8080 -v ~/Downloads:/books evanbuss/openbooks --name my_irc_name --persist`
 
 ### Host at a sub path behind a reverse proxy
 
-`docker run -d -p 8080:80 -e BASE_PATH=/openbooks/ evanbuss/openbooks --name my_irc_name`
+`docker run -d -p 8080:8080 -e BASE_PATH=/openbooks/ evanbuss/openbooks --name my_irc_name`
 
 ## Arguments
 
@@ -32,7 +32,7 @@ version: '3.3'
 services:
     openbooks:
         ports:
-            - '8080:80'
+            - '8080:8080'
         volumes:
             - 'booksVolume:/books'
         restart: unless-stopped

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -12,11 +12,11 @@ If you'd prefer to use OpenBooks from your terminal, check out [CLI Mode](./conf
 
 ### Docker
 
-`docker run -p 8080:80 evanbuss/openbooks`
+`docker run -p 8080:8080 evanbuss/openbooks`
 
 : Basic configuration that exposes the web interface on [http://localhost:8080](http://localhost:8080) and saves all files to an anonymous volume.
 
-`docker run -p 8080:80 -v ~/Downloads/openbooks:/books evanbuss/openbooks --persist`
+`docker run -p 8080:8080 -v ~/Downloads/openbooks:/books evanbuss/openbooks --persist`
 
 : More advanced configuration that exposes the web interface on [http://localhost:8080](http://localhost:8080) and persists all eBook files to the mounted volume at `~/Downloads/openbooks`.
 

--- a/docs/docs/setup/docker.md
+++ b/docs/docs/setup/docker.md
@@ -15,7 +15,7 @@ services:
     image: evanbuss/openbooks:latest
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - "~/Downoads/openbooks:/books"
     command: --persist --name
@@ -28,6 +28,58 @@ services:
 See the [configuration docs](../configuration.md) for a complete list of Server mode configuration options. Pass the configuration flags into the `command` property.
 
 Use the `environment` property to optionally set a custom base path for the server.
+
+## Running as a non-root user
+
+The image is built on `gcr.io/distroless/static`, which has no shell and therefore **does not honor the linuxserver.io-style `PUID`/`PGID` environment variables** — there's no entrypoint script to read them. Setting `PUID=1000` will be silently ignored, and the container will continue to run as root.
+
+Use Docker's native `--user` flag (or the compose `user:` directive) instead. The default port is `8080` (non-privileged), so this works without any command override.
+
+### Docker CLI
+
+```bash
+# One-time on the host: make sure the bind mount is owned by your UID,
+# otherwise the container can't write downloads to it.
+sudo chown -R "$(id -u):$(id -g)" ~/Downloads/openbooks
+
+docker run \
+  --user "$(id -u):$(id -g)" \
+  -p 8080:8080 \
+  -v ~/Downloads/openbooks:/books \
+  evanbuss/openbooks --name my_irc_name --persist
+```
+
+### Docker Compose
+
+```yaml title="docker-compose.yml"
+version: "3.3"
+services:
+  openbooks:
+    container_name: OpenBooks
+    image: evanbuss/openbooks:latest
+    user: "${PUID}:${PGID}"  # native Docker user mapping; despite the
+                             # PUID/PGID names this is NOT the
+                             # linuxserver.io convention - we just
+                             # reuse the env-var spelling for muscle
+                             # memory.
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - "~/Downloads/openbooks:/books"
+    command: --persist --name my_irc_name
+    environment:
+      - BASE_PATH=/openbooks/
+```
+
+Define `PUID` and `PGID` either in a `.env` file next to the compose file or as Portainer "Environment variables" on the stack:
+
+```
+PUID=1000
+PGID=1000
+```
+
+After the container starts, verify the mapping took effect by checking host-side file ownership of any newly downloaded book — it should match your UID, not `0`.
 
 ## Image Tags
 


### PR DESCRIPTION
## Summary

Closes #10.

- `Dockerfile` ENTRYPOINT defaults to `--port 8080` (and `EXPOSE 8080`) so the image runs cleanly under `docker run --user UID:GID …` or compose's `user:` directive — no more privileged-port bind error, no command override needed.
- All `-p 8080:80` examples bumped to `-p 8080:8080` in: `README.md`, `docker.md`, `docs/docs/getting-started.md`, `docs/docs/setup/docker.md`.
- New **Running as a non-root user** section in `docs/docs/setup/docker.md` covering the CLI `--user` flag, the equivalent compose `user:` directive, the host-side `chown` prerequisite, and an explicit note that `PUID`/`PGID` env vars are *not* the linuxserver.io convention on this image.

## Breaking change note

Anyone copy-pasting the old `docker run -p 8080:80 …` examples will get a connection refused on the host port until they update to `-p 8080:8080`. This fork's audience is small and controlled, so acceptable. Mentioned in the commit message.

## Test plan

- [x] `grep -RnE '8080:80[^0-9]|--port +80[^0-9]' README.md docker.md docs/ Dockerfile` returns nothing
- [ ] CI builds the image and pushes `:pr-N`
- [ ] Manual: `docker run --user "$(id -u):$(id -g)" -p 8080:8080 -v /tmp/books:/books ghcr.io/abnormalend/openbooks:pr-N` starts and listens (assuming `/tmp/books` is owned by your UID)
- [ ] Open `http://localhost:8080`, do a search, verify downloads land in `/tmp/books` owned by your UID, not root

## Out of scope (left for follow-up if wanted)

Honoring `PUID`/`PGID` natively would require swapping `gcr.io/distroless/static` for a shell-bearing base + entrypoint script — ~4× image size, not worth the maintenance. Documented as such in the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)